### PR TITLE
The RNG misses the simple types

### DIFF
--- a/RelaxNG/sbml-core/sbml-core-v2.rng
+++ b/RelaxNG/sbml-core/sbml-core-v2.rng
@@ -3,12 +3,12 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
   datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   
-  <!-- The following are the core SBML data classes -->
+ <!-- The following are the core SBML data classes -->
  <!-- these will all need l3v2 variants -->
 
+ <include href="sbml-simple-types.rng"/>
  <include href="sbml-sbase-l3v2.rng"/>
  <include href="sbml-core-l3v2.rng"/>
-  <include href="sbml-mathml-l3v2.rng"/>
-  
+ <include href="sbml-mathml-l3v2.rng"/> 
  
 </grammar>


### PR DESCRIPTION
I just tried an RNG to XSD conversion and the simple types were missing.
```
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-sbase-l3v2.rng:15:41: error: reference to undefined pattern "SBOTerm.simpleType"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-sbase-l3v2.rng:20:37: error: reference to undefined pattern "SId.simpleType"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-sbase-l3v2.rng:34:44: error: reference to undefined pattern "annotation.datatype"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-sbase-l3v2.rng:39:39: error: reference to undefined pattern "xhtml.datatype"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-mathml-l3v2.rng:8:62: error: sorry, externalRef is not yet supported
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-core-l3v2.rng:178:46: error: reference to undefined pattern "BaseUnitSIdRef.simpleType"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-core-l3v2.rng:218:44: error: reference to undefined pattern "UnitSIdRef.simpleType"
/home/mkoenig/git/sbml-specifications/RelaxNG/sbml-core/sbml-core-l3v2.rng:242:38: error: reference to undefined pattern "SIdRef.simpleType"
```
Most likely similar issue in the other RNG schemas.